### PR TITLE
Fix theme selection in Gallery Ripper

### DIFF
--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -106,7 +106,7 @@ class GalleryRipperApp(ThemedTk):
         dark_themes = [th for th in self.get_themes() if "dark" in th or th in ("arc", "black", "equilux", "plastik", "radiance")]
         if not dark_themes:
             dark_themes = self.get_themes()
-        self.theme_var = tk.StringVar(value=self.get_theme())
+        self.theme_var = tk.StringVar(value=self.current_theme)
         frm_theme = tk.Frame(self)
         frm_theme.pack(fill="x", pady=5, padx=10)
         tk.Label(frm_theme, text="Theme:").pack(side="left")


### PR DESCRIPTION
## Summary
- fix theme retrieval by using ThemedTk's `current_theme`

## Testing
- `python -m py_compile gallery_ripper.py`

------
https://chatgpt.com/codex/tasks/task_e_686da15ecb0c8320b852981fa46ed8c4