### PR TITLE
Improve Coppermine image parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ No thumbnails—just full images, organized by album.
 
    ```bash
    pip install -r requirements.txt
+   ```
+
+3. **Run the application:**
+
+   ```bash
+   python gallery_ripper.py
+   ```
 
 ## License
 


### PR DESCRIPTION
## Summary
- improve JS variable extraction for Coppermine pages
- fix README installation section

## Testing
- `python -m py_compile gallery_ripper.py`

------
https://chatgpt.com/codex/tasks/task_e_686db32557a883208326ef029120805b