### PR TITLE
Fix tree selection behavior

### DIFF
--- a/gallery_ripper.py
+++ b/gallery_ripper.py
@@ -665,6 +665,7 @@ class GalleryRipperApp(tb.Window):
 
         self.tree.bind("<<TreeviewSelect>>", self.on_tree_select)
         self.tree.bind("<Double-1>", self.on_tree_doubleclick)
+        self.tree.bind("<Button-1>", self.on_tree_click)
 
     def select_folder(self):
         folder = filedialog.askdirectory()
@@ -747,8 +748,20 @@ class GalleryRipperApp(tb.Window):
         if self.tree.get_children(item):
             self.tree.item(item, open=not self.tree.item(item, "open"))
 
+    def on_tree_click(self, event):
+        """Prevent selection changes when clicking expand/collapse arrow."""
+        item = self.tree.identify_row(event.y)
+        region = self.tree.identify("region", event.x, event.y)
+        if region == "tree":
+            bbox = self.tree.bbox(item)
+            if bbox and event.x < bbox[0] + 20:
+                return "break"
+
     def select_all_leaf_albums(self):
         for item in self.item_to_album:
+            label = self.tree.item(item, "text")
+            if label.lstrip().startswith("\u2605"):
+                continue
             self.selected_album_urls.add(item)
             self.tree.selection_add(item)
             self.tree.set(item, "sel", "\u2611")


### PR DESCRIPTION
## Summary
- prevent unintentional deselection when collapsing/expanding tree nodes
- ignore special albums when using "Select All"

## Testing
- `python -m py_compile gallery_ripper.py`

------
https://chatgpt.com/codex/tasks/task_e_686e0db0f7408320a989a20ea76fa0e3